### PR TITLE
商品一覧表示機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
   def index
+    @items = Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
   def index
-    @items = Item.all
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,7 +11,8 @@ class Item < ApplicationRecord
 
   validates :image, :item_name, :text, :price, presence: true
   validates :price,
-            numericality: { with: /\A[0-9]+\z/, greater_than: 300, less_than: 10_000_000, message: 'は300円から9,999,999円の範囲で入力してください,また半角数字のみ入力できます' }
+            numericality: { with: /\A[0-9]+\z/, greater_than: 300, less_than: 10_000_000,
+                            message: 'は300円から9,999,999円の範囲で入力してください,また半角数字のみ入力できます' }
 
   with_options numericality: { other_than: 1, message: "can't be blank" } do
     validates :category_id
@@ -19,6 +20,5 @@ class Item < ApplicationRecord
     validates :send_fee_id
     validates :prefecture_id
     validates :send_period_id
-    
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,11 +126,11 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= link_to image_tag(item.image, class: "item-img"), items_path(item.id),method: :get  %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -141,22 +141,20 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.item_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.send_fee.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
             </div>
           </div>
         </div>
-        <% end %>
+     <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+    <% end %>
+      <% if @items.length == 0 %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -174,9 +172,8 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-    </ul>
+      <% end %>
+        </ul>
   </div>
   <%# /商品一覧 %>
 </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,8 +125,8 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-　　<% if @items[0] != nil %>　
-     <% @items.each do |item| %>
+
+    <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
@@ -153,7 +153,6 @@
         </div>
      <% end %>
       </li>
-     <% end %>
     <% end %>
       <% if @items.length == 0 %>
       <li class='list'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,7 +125,7 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
+　　<% if @items[0] != nil %>
     <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
@@ -153,6 +153,7 @@
         </div>
      <% end %>
       </li>
+    <% end %>
     <% end %>
       <% if @items.length == 0 %>
       <li class='list'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,8 +125,8 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
-    <% @items.each do |item| %>
+　　<% if @items[0] != nil %>　
+     <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
@@ -153,6 +153,7 @@
         </div>
      <% end %>
       </li>
+     <% end %>
     <% end %>
       <% if @items.length == 0 %>
       <li class='list'>

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,9 +1,8 @@
 FactoryBot.define do
   factory :item do
-    
     item_name { 'aaaa' }
     text { 'aaaa' }
-    category_id {2}
+    category_id { 2 }
     state_id { 2 }
     send_fee_id { 2 }
     prefecture_id { 2 }

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Item', type: :model do
     end
 
     it 'priceが10,000,000以上では登録できないこと' do
-      @item.price = 10000000
+      @item.price = 10_000_000
       @item.valid?
       expect(@item.errors.full_messages).to include('Price は300円から9,999,999円の範囲で入力してください,また半角数字のみ入力できます')
     end
@@ -86,8 +86,6 @@ RSpec.describe 'Item', type: :model do
       @item.valid?
       expect(@item.errors.full_messages).to include('Price は300円から9,999,999円の範囲で入力してください,また半角数字のみ入力できます')
     end
-
-
 
     it 'imageが空では保存できないこと' do
       @item.image = nil


### PR DESCRIPTION
# What
商品一覧表示機能の実装

# Why
インデックスに出品済の商品を表示させる

```
各種画像と動画

画像が表示されており、画像がリンク切れなどになっていない
出品した商品の一覧表示ができていること
「画像/価格/商品名」の3つの情報について表示できていること

https://gyazo.com/4ae88e232794a00c35411b602ed986ab

上から、出品された日時が新しい順に表示されること　
DB画像
https://gyazo.com/711a2e7e28405ae44c573b6b0a961c81

ログアウト状態のユーザーでも、商品一覧表示ページを見ることができること
https://gyazo.com/3617129a4c6559132421fbdc9af0870e

```

確認お願いします。